### PR TITLE
Fix: Trigger auto-pr workflow on push and workflow_call

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - "**"
+  workflow_call:
+    
 
 jobs:
   pull_request:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add support for triggering the auto-pr workflow via workflow_call event, expanding its invocation flexibility