### PR TITLE
Fixes Gitleaks by setting safe directory correctly

### DIFF
--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: GitLeaks
         run: |
-          git config --global --add safe.directory /__w/
+          git config --global --add safe.directory "${{ github.workspace }}"
           gitleaks detect --verbose
   vulnerabilities:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary by Sourcery

Configure Git safe directory for Gitleaks to correctly scan the repository in GitHub Actions

Bug Fixes:
- Fix Gitleaks detection by correctly setting the Git safe directory to the current workspace

CI:
- Update GitHub Actions workflow to set the safe directory path dynamically using the GitHub workspace environment variable