### PR TITLE
Adds checkout step to check-licenses action

### DIFF
--- a/.github/actions/check-licenses-action/action.yaml
+++ b/.github/actions/check-licenses-action/action.yaml
@@ -10,6 +10,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Setup .NET
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
       with:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add the `actions/checkout` step to the `check-licenses-action` composite action to ensure the repository code is available before subsequent steps.