### PR TITLE
Add dotnet restore command before installing nuget-license tool in GitHub action

### DIFF
--- a/.github/actions/check-licenses-action/action.yaml
+++ b/.github/actions/check-licenses-action/action.yaml
@@ -24,6 +24,7 @@ runs:
         ALLOWED_LICENSES_PATH: ${{ inputs.allowed_licenses_path }}
         IGNORED_PACKAGES_PATH: ${{ inputs.ignored_packages_path }}
       run: |
+        dotnet restore
         dotnet tool install --global nuget-license || continue
         PATH=/root/.dotnet/tools:$PATH
         solution=$(find . -type f -name '*.slnx')


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Run `dotnet restore` before installing the `nuget-license` tool in the `check-licenses-action`.