### PR TITLE
Update license check to output to a directory

### DIFF
--- a/.github/actions/check-licenses-action/action.yaml
+++ b/.github/actions/check-licenses-action/action.yaml
@@ -33,6 +33,7 @@ runs:
           solution=$(find . -type f -name '*.sln')
         fi
         
+        mkdir out
         output_path="out/licenses.json"
         nuget-license \
          --input "$solution" \


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the `check-licenses-action` to save the `licenses.json` output file into a new `out` directory.