### PR TITLE
Add concurrency groups to workflows

### DIFF
--- a/.github/actions/check-licenses-action/action.yaml
+++ b/.github/actions/check-licenses-action/action.yaml
@@ -38,7 +38,7 @@ runs:
         nuget-license \
          --input "$solution" \
          --include-shared-projects \
-         --output table \
+         --output jsonpretty \
          --allowed-license-types "$ALLOWED_LICENSES_PATH" \
          --ignored-packages "$IGNORED_PACKAGES_PATH" \
          --file-output "$output_path"

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -6,6 +6,10 @@ on:
         description: "Github token"
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pull_request:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -24,6 +24,11 @@ on:
       cosignPassword:
         description: "Cosign password"
         required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   version:
     uses: innago-property-management/Oui-DELIVER/.github/workflows/semver.yml@main

--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -13,6 +13,10 @@ on:
         description: "Path to the ignored packages JSON file"
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sast:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary by Sourcery

Add concurrency controls to CI workflows and update license check output format.

CI:
- Add concurrency groups to the `build-publish`, `auto-pr`, and `merge-checks` workflows to cancel older runs when new ones are triggered for the same ref.
- Update the `check-licenses-action` to use `jsonpretty` output format for `nuget-license`.