### PR TITLE
Adds ArgoCD automatic updates after image publish.

### DIFF
--- a/.github/actions/update-argocd/action.yaml
+++ b/.github/actions/update-argocd/action.yaml
@@ -1,0 +1,59 @@
+name: "Update ArgoCD"
+description: "Updates the values file in an ArgoCD repo"
+inputs:
+  githubToken:
+    required: true
+    description: "GitHub token"
+  repoName:
+    required: true
+    description: "ArgoCD repo name"
+  version:
+    required: true
+    description: "Image Version"
+  folderName:
+    required: true
+    description: "Folder name containing the helm values files"
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout ArgoCD Repo
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      with:
+        repository: '${{ inputs.repoName }}'
+        ref: main
+        token: '${{ inputs.githubToken }}'
+    - name: configure git
+      shell: bash
+      run: |
+        git config --unset-all http.https://github.com/.extraheader
+        git config user.name "Innago CD bot"
+        git config user.email "<>"
+    - name: install yq
+      uses: install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b # 1.3.1
+    - name: version
+      env:
+        tag: "${{ inputs.version }}"
+        folderName: "${{ inputs.folderName }}"
+        repoName: "${{ inputs.repoName }}"
+      shell: bash
+      run: |-
+        folderName=$(echo $folderName | tr '[:upper:]' '[:lower:]')
+        repoName=$(echo $repoName | tr '[:upper:]' '[:lower:]')
+        if [[ "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          environment="stage"
+        elif [[ "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc-[0-9]+$ ]]; then
+          environment="qa"
+        elif [[ "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+-.* ]]; then
+          environment="dev"
+        else
+          echo "Error: Tag '$tag' does not match any known pattern."
+          exit 1
+        fi
+
+        filename="value-overrides-${environment}.yaml"
+        git checkout -b "automated/${folderName} ${version}"
+        yq --inplace ".image.tag=\"${version}\"" "values/${folderName}/${filename}"
+        yq --inplace ".migrationJob.image.tag=\"${version}\"" "values/${folderName}/${filename}"
+        git stage "${filename}"
+        git commit --message="Update $env to version ${version}"
+        git push

--- a/.github/actions/update-argocd/action.yaml
+++ b/.github/actions/update-argocd/action.yaml
@@ -54,6 +54,6 @@ runs:
         git checkout -b "automated/${folderName} ${version}"
         yq --inplace ".image.tag=\"${version}\"" "values/${folderName}/${filename}"
         yq --inplace ".migrationJob.image.tag=\"${version}\"" "values/${folderName}/${filename}"
-        git stage "${filename}"
+        git add "${filename}"
         git commit --message="Update $env to version ${version}"
         git push

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -14,6 +14,11 @@ on:
         description: "Image Name. Omit if there is no Docker image to build."
         type: string
         default: ''
+      argoCdRepoName:
+        required: false
+        description: "ArgoCD repo name. Omit if no image."
+        type: string
+        default: ''
     secrets:
       githubToken:
         description: "Github token"
@@ -79,3 +84,11 @@ jobs:
           sha: ${{ github.sha }}
           cosignKey: ${{secrets.cosignKey}}
           cosignPassword: ${{secrets.cosignPassword}}
+      - name: Update ArgoCD
+        if: inputs.imageName != ''
+        uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@main
+        with:
+          githubToken: "${{ secrets.githubToken }}"
+          repoName: $"{{ inputs.argoCdRepoName }}"
+          version: ${{ needs.version.outputs.version }}
+          folderName: ${{ github.event.repository.name }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -88,7 +88,7 @@ jobs:
         if: inputs.imageName != ''
         uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@main
         with:
-          githubToken: "${{ secrets.githubToken }}"
-          repoName: $"{{ inputs.argoCdRepoName }}"
+          githubToken: ${{ secrets.githubToken }}
+          repoName: ${{ inputs.argoCdRepoName }}
           version: ${{ needs.version.outputs.version }}
           folderName: ${{ github.event.repository.name }}


### PR DESCRIPTION
## Summary by Sourcery

Automate ArgoCD application updates following successful image publishing.

CI:
- Modify the `build-publish.yml` workflow to optionally trigger an ArgoCD update step after publishing an image.
- Introduce a new reusable GitHub Action (`update-argocd`) to update image tags in a target ArgoCD repository's Helm values file based on the published image version and inferred environment.