### PR TITLE
Sets upstream branch for automated deployments.

### DIFF
--- a/.github/actions/update-argocd/action.yaml
+++ b/.github/actions/update-argocd/action.yaml
@@ -51,11 +51,12 @@ runs:
         fi
 
         fileName="value-overrides-${environment}.yaml"
-        git checkout -b "automated/${folderName}-${version}"
+        branchName="automated/${folderName}-${tag}"
+        git checkout -b "${branchName}"
         fullName="helm-values/${folderName}/${fileName}"
         fullName=$(realpath "${fullName}")
-        yq --inplace ".image.tag=\"${version}\"" "${fullName}"
-        yq --inplace ".migrationJob.image.tag=\"${version}\"" "${fullName}"
-        git add  "${fullName}"
-        git commit --message="Update ${env} to version ${version}"
-        git push
+        yq --inplace ".image.tag=\"${tag}\"" "${fullName}"
+        yq --inplace ".migrationJob.image.tag=\"${tag}\"" "${fullName}"
+        git add "${fullName}"
+        git commit --message="Update ${environment} to version ${tag}"
+        git push --set-upstream origin "${branchName}"


### PR DESCRIPTION
## Summary by Sourcery

Update the ArgoCD update action to use the image tag for branch naming and commit messages.

CI:
- Modify the `update-argocd` action to use the `tag` input variable instead of `version`.
- Standardize the automated branch name format to `automated/${folderName}-${tag}`.
- Update the commit message format to use the `environment` and `tag` variables.