### PR TITLE
Use github.actor as git user name

### DIFF
--- a/.github/actions/update-argocd/action.yaml
+++ b/.github/actions/update-argocd/action.yaml
@@ -25,15 +25,15 @@ runs:
     - name: configure git
       env:
         token: ${{ inputs.githubToken }}
-        username: ${{ github.actor }}
+        userName: ${{ github.actor }}
         repoName: ${{ inputs.repoName }}
       shell: bash
       run: |
         git config --unset-all http.https://github.com/.extraheader
-        git config user.name "Innago CD bot"
+        git config user.name "${userName}"
         git config user.email "<>"
-        origin="https://${ username }:${token}@github.com/${repoName}"
-        git remote set-url origin "${ origin }"
+        origin="https://${userName}:${token}@github.com/${repoName}"
+        git remote set-url origin "${origin}"
     - name: install yq
       uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b # 1.3.1
     - name: update ArgoCD


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set the git user name to `github.actor` in the `update-argocd` action instead of a hardcoded bot name.