### PR TITLE
Fixes outdated check to support .sln files

### DIFF
--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -77,7 +77,14 @@ jobs:
         run: |
           PATH=/root/.dotnet/tools:$PATH
           dotnet tool install --global dotnet-outdated-tool
-          dotnet outdated *.slnx \
+          
+          solution=$(find . -type f -name '*.slnx')
+        
+          if [[ -z $solution ]]; then
+            solution=$(find . -type f -name '*.sln')
+          fi
+          
+          dotnet outdated "${solution}" \
             --output outdated.json \
             --fail-on-updates \
             --version-lock Major


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Modify the workflow script to find either a `.slnx` or `.sln` file and use it for the `dotnet outdated` check.