### PR TITLE
Fixes GitHub package source configuration

### DIFF
--- a/.github/actions/check-licenses-action/action.yaml
+++ b/.github/actions/check-licenses-action/action.yaml
@@ -28,13 +28,14 @@ runs:
       run: |
         dotnet nuget add source \
           --name "github" \
-          --source "https://nuget.pkg.github.com/innago-property-management/index.json" \
           --username "$GHCR_USER" \
           --password "$GHCR_TOKEN" \
-          --non-interactive
+          "https://nuget.pkg.github.com/innago-property-management/index.json"
+        
         dotnet restore
         dotnet tool install --global nuget-license || continue
         PATH=/root/.dotnet/tools:$PATH
+        
         solution=$(find . -type f -name '*.slnx')
         
         if [[ -z $solution ]]; then

--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -12,10 +12,11 @@ on:
         required: true
         description: "Path to the ignored packages JSON file"
         type: string
-#    secrets: 
-#      githubToken:
-#        description: "Github token"
-#        required: true
+    secrets: 
+      githubToken:
+        description: "Github token - deprecated"
+        required: false
+        
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -61,10 +62,12 @@ jobs:
         run: |
           dotnet nuget add source \
             --name "github" \
-            --source "https://nuget.pkg.github.com/innago-property-management/index.json" \
             --username "$GHCR_USER" \
-            --password "$GHCR_TOKEN"
+            --password "$GHCR_TOKEN" \
+            "https://nuget.pkg.github.com/innago-property-management/index.json"
+          
           dotnet restore
+          
           dotnet list package --vulnerable --include-transitive 2>&1 | tee vuln.log
           cat vuln.log >> $GITHUB_STEP_SUMMARY
           
@@ -94,9 +97,10 @@ jobs:
         run: |
           dotnet nuget add source \
             --name "github" \
-            --source "https://nuget.pkg.github.com/innago-property-management/index.json" \
             --username "$GHCR_USER" \
-            --password "$GHCR_TOKEN"
+            --password "$GHCR_TOKEN" \
+            "https://nuget.pkg.github.com/innago-property-management/index.json"
+          
           PATH=/root/.dotnet/tools:$PATH
           dotnet tool install --global dotnet-outdated-tool
           


### PR DESCRIPTION
Adds the source URL to the correct position in the `dotnet nuget add source` command arguments and uncomments the GitHub token.

## Summary by Sourcery

Fix GitHub package source configuration in workflow and action files by correcting the `dotnet nuget add source` command argument order

CI:
- Reordered source URL argument in GitHub workflow and action files
- Updated GitHub token secret configuration