### PR TITLE
Store NuGet credentials in clear text

### DIFF
--- a/.github/actions/build-dotnet/action.yaml
+++ b/.github/actions/build-dotnet/action.yaml
@@ -31,7 +31,16 @@ runs:
         MINIMUM_COVERAGE: ${{ inputs.minimumCoverage }}
         REPORTS_PATH: test/results
         TEST_PROJECT_PATH: "${{ inputs.testProjectPath }}"
+        GHCR_USER: ${{ github.actor }}
+        GHCR_TOKEN: ${{ secrets.githubToken }}
       run: |
+        dotnet nuget add source \
+          --name "github" \
+          --username "$GHCR_USER" \
+          --password "$GHCR_TOKEN" \
+          --store-password-in-clear-text \
+          "https://nuget.pkg.github.com/innago-property-management/index.json"
+        
         dotnet restore
         dotnet build --configuration Release --no-restore /p:Version="$VERSION"
         dotnet test ${TEST_PROJECT_PATH} \

--- a/.github/actions/check-licenses-action/action.yaml
+++ b/.github/actions/check-licenses-action/action.yaml
@@ -33,6 +33,7 @@ runs:
           --name "github" \
           --username "$GHCR_USER" \
           --password "$GHCR_TOKEN" \
+          --store-password-in-clear-text \
           "https://nuget.pkg.github.com/innago-property-management/index.json"
         
         dotnet restore

--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -59,7 +59,12 @@ jobs:
           GHCR_USER: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.githubToken }}
         run: |
-          dotnet nuget add source --name "github" --username "$GHCR_USER" --password "$GHCR_TOKEN" "https://nuget.pkg.github.com/innago-property-management/index.json"
+          dotnet nuget add source \
+            --name "github" \
+            --username "$GHCR_USER" \
+            --password "$GHCR_TOKEN" \
+            --store-password-in-clear-text \
+            "https://nuget.pkg.github.com/innago-property-management/index.json"
           
           dotnet restore
           
@@ -94,6 +99,7 @@ jobs:
             --name "github" \
             --username "$GHCR_USER" \
             --password "$GHCR_TOKEN" \
+            --store-password-in-clear-text \
             "https://nuget.pkg.github.com/innago-property-management/index.json"
           
           PATH=/root/.dotnet/tools:$PATH


### PR DESCRIPTION
## Summary by Sourcery

Configure NuGet package source authentication by storing GitHub Package Registry credentials in clear text across multiple GitHub workflow files

CI:
- Added --store-password-in-clear-text flag when adding NuGet source in GitHub Actions workflows

Chores:
- Added GitHub Package Registry authentication to multiple GitHub workflow and action files