### PR TITLE
Use input for GitHub token in license check

### DIFF
--- a/.github/actions/check-licenses-action/action.yaml
+++ b/.github/actions/check-licenses-action/action.yaml
@@ -25,7 +25,7 @@ runs:
       shell: bash
       env:
         GHCR_USER: ${{ github.actor }}
-        GHCR_TOKEN: ${{ secrets.githubToken }}
+        GHCR_TOKEN: ${{ inputs.githubToken }}
         ALLOWED_LICENSES_PATH: ${{ inputs.allowed_licenses_path }}
         IGNORED_PACKAGES_PATH: ${{ inputs.ignored_packages_path }}
       run: |

--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -37,7 +37,7 @@ jobs:
       - name: GitLeaks
         shell: bash
         env: 
-          GITHUB_TOKEN: "${{ secrets.ORG_GHCR_NUGET_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.githubToken }}"
         run: |
           REPO_NAME=$(echo "${{ github.repository }}" | cut -d '/' -f 2)
           WORK_DIR="/__w/${{ github.repository_owner }}/${REPO_NAME}"


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions workflows to use input-based GitHub token instead of hardcoded secrets

Enhancements:
- Modify license check action to accept GitHub token as an input parameter

CI:
- Update merge-checks workflow to use githubToken secret consistently