### PR TITLE
Removes duplicate GITHUB_TOKEN environment variable

### DIFF
--- a/.github/actions/check-licenses-action/action.yaml
+++ b/.github/actions/check-licenses-action/action.yaml
@@ -26,6 +26,7 @@ runs:
       env:
         GHCR_USER: ${{ github.actor }}
         GHCR_TOKEN: ${{ inputs.githubToken }}
+        NuGetPackageSourceCredentials_github: "Username=${{ github.actor }};Password=${{ inputs.githubToken }}"
         ALLOWED_LICENSES_PATH: ${{ inputs.allowed_licenses_path }}
         IGNORED_PACKAGES_PATH: ${{ inputs.ignored_packages_path }}
       run: |

--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -58,7 +58,6 @@ jobs:
         env:
           GHCR_USER: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.githubToken }}
-          GITHUB_TOKEN: ${{ secrets.githubToken }}
           NuGetPackageSourceCredentials_github: "Username=${{ github.actor }};Password=${{ secrets.githubToken }}"
         run: |
           dotnet nuget add source \
@@ -95,7 +94,6 @@ jobs:
         env:
           GHCR_USER: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.githubToken }}
-          GITHUB_TOKEN: ${{ secrets.githubToken }}
           NuGetPackageSourceCredentials_github: "Username=${{ github.actor }};Password=${{ secrets.githubToken }}"
         shell: bash
         run: |


### PR DESCRIPTION
## Summary by Sourcery

Remove duplicate GITHUB_TOKEN environment variable in GitHub Actions workflows

CI:
- Updated check-licenses-action to add NuGetPackageSourceCredentials_github environment variable

Chores:
- Removed redundant GITHUB_TOKEN environment variable from merge-checks.yml workflow