### PR TITLE
Fixes GitHub token reference in workflow

### DIFF
--- a/.github/actions/build-dotnet/action.yaml
+++ b/.github/actions/build-dotnet/action.yaml
@@ -10,7 +10,8 @@ inputs:
     default: "0"
   githubToken:
     required: true
-    description: "Github Token - for cobertura action"
+    description: "Github Token for publish"
+  
   testProjectPath:
     required: true
     description: "Test project discovery is from the solution if this is not set."

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   pull_request:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: pull-request

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -82,10 +82,10 @@ jobs:
           minimumCoverage: "${{ inputs.minimumCoverage }}"
           testProjectPath: "${{ inputs.testProjectPath }}"      
       - name: Push Nuget packages
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+#        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         uses: innago-property-management/Oui-DELIVER/.github/actions/push-nuget-packages@main
         with:
-          githubToken: "${{ secrets.githubToken }}"
+          githubToken: "${{ secrets.GITHUB_TOKEN }}"
       - name: Generate SBOM
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         uses: innago-property-management/Oui-DELIVER/.github/actions/generate-sbom-dotnet@main

--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -24,12 +24,14 @@ concurrency:
 jobs:
   sast:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: semgrep-action
         uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d #v1
   secrets:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     container:
       image: ghcr.io/gitleaks/gitleaks:latest
     steps:
@@ -47,6 +49,7 @@ jobs:
           gitleaks detect --verbose --source . --log-level trace
   vulnerabilities:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup .NET
@@ -82,6 +85,7 @@ jobs:
           fi
   outdated:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup .NET
@@ -132,6 +136,7 @@ jobs:
           json_file_path: outdatedProjects.json
   licenses:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       - name: Check licenses
         uses: innago-property-management/Oui-DELIVER/.github/actions/check-licenses-action@main

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   version:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     outputs:
       version: ${{ steps.get_latest_tag.outputs.version }}
     steps:


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub workflow to use the correct GitHub token for package publishing

CI:
- Modified GitHub Actions workflow to use GITHUB_TOKEN instead of a custom githubToken secret

Chores:
- Updated action.yaml description for GitHub token input