### PR TITLE
Rename GITHUB_TOKEN to PUSH_TOKEN for clarity

### DIFF
--- a/.github/actions/push-nuget-packages/action.yaml
+++ b/.github/actions/push-nuget-packages/action.yaml
@@ -1,7 +1,7 @@
 name: "Push NuGet packages"
 description: "Uploads NuGet packages to GitHub"
-inputs: 
-  githubToken:
+inputs:
+  pushToken:
     required: true
     description: "GitHub token"
 runs:
@@ -10,11 +10,11 @@ runs:
     - name: Push Nuget packages
       shell: bash
       env: 
-        GITHUB_TOKEN: "${{ inputs.githubToken }}"
+        PUSH_TOKEN: "${{ inputs.pushToken }}"
       run: |
         find . -path '**/bin/Release/*.nupkg' -print0 | while IFS= read -r -d $'\0' file; do 
           dotnet nuget push "$file" \
             --source "https://nuget.pkg.github.com/innago-property-management/index.json" \
-            --api-key "${{ env.GITHUB_TOKEN }}" \
+            --api-key "${PUSH_TOKEN}" \
             --skip-duplicate
         done

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -85,7 +85,7 @@ jobs:
 #        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         uses: innago-property-management/Oui-DELIVER/.github/actions/push-nuget-packages@main
         with:
-          githubToken: "${{ secrets.GITHUB_TOKEN }}"
+          pushToken: "${{ secrets.githubToken }}"
       - name: Generate SBOM
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         uses: innago-property-management/Oui-DELIVER/.github/actions/generate-sbom-dotnet@main


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Renamed environment variable and input parameter from GITHUB_TOKEN to PUSH_TOKEN in GitHub Actions configuration