### PR TITLE
Changed build-publish.yml and action.yaml to read the nuget pull from github source if docker build is running.

### DIFF
--- a/.github/actions/build-publish-sign-docker/action.yaml
+++ b/.github/actions/build-publish-sign-docker/action.yaml
@@ -38,6 +38,10 @@ inputs:
   cosignPassword:
     required: true
     description: "Password for Cosign key"
+  buildArgs:
+    required: false
+    description: "Optional build arguments for Docker build (e.g., NUGET_SOURCE_URL=...)"
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -79,6 +83,7 @@ runs:
           org.opencontainers.image.url=${{ inputs.repositoryUrl }}
           org.opencontainers.image.revision=${{ inputs.sha }}
           org.opencontainers.image.version=${{ inputs.version }}
+        build-args: ${{ inputs.buildArgs }}
     - name: sign container image
       run: |
         cosign sign --key env://COSIGN_KEY "${{ env.IMAGE }}@${{ env.DIGEST }}" --recursive=true --yes=true

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -22,6 +22,17 @@ on:
         description: "Test project discovery is from the solution if this is not set."
         default: "."
         type: string
+      nugetSourceName:
+        required: false
+        description: "Name for the NuGet source (e.g., github)"
+        type: string
+        default: 'github'
+      nugetSourceUrl:
+        required: false
+        description: "URL of the NuGet source"
+        type: string
+        default: 'https://nuget.pkg.github.com/innago-property-management/index.json'
+
   workflow_call:
     inputs:
       imageName:
@@ -44,6 +55,17 @@ on:
         description: "Test project discovery is from the solution if this is not set."
         default: "."
         type: string
+      nugetSourceName:
+        required: false
+        description: "Name for the NuGet source (e.g., github)"
+        type: string
+        default: 'github'
+      nugetSourceUrl:
+        required: false
+        description: "URL of the NuGet source"
+        type: string
+        default: 'https://nuget.pkg.github.com/innago-property-management/index.json'
+
     secrets:
       githubToken:
         description: "Github token"
@@ -111,6 +133,11 @@ jobs:
           sha: ${{ github.sha }}
           cosignKey: ${{secrets.cosignKey}}
           cosignPassword: ${{secrets.cosignPassword}}
+          buildArgs: |
+            NUGET_SOURCE_NAME: ${{ inputs.nugetSourceName }}
+            NUGET_SOURCE_URL: ${{ inputs.nugetSourceUrl }}
+            NUGET_USERNAME: ${{ github.actor }}
+            NUGET_PASSWORD: ${{ secrets.githubToken }}
       - name: Update ArgoCD
         if: inputs.imageName != ''
         uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@main


### PR DESCRIPTION
## Summary by Sourcery

Expose GitHub NuGet feed settings as workflow inputs and forward them as build arguments in Docker builds to enable pulling packages from a GitHub NuGet source.

New Features:
- Add `nugetSourceName` and `nugetSourceUrl` inputs to the build-publish workflow for customizable NuGet feed configuration
- Add an optional `buildArgs` input to the build-publish-sign-docker composite action

Enhancements:
- Pass `NUGET_SOURCE_NAME`, `NUGET_SOURCE_URL`, `NUGET_USERNAME`, and `NUGET_PASSWORD` as Docker build arguments during the image build