### PR TITLE
Some fixes on getting token in build args

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -134,10 +134,10 @@ jobs:
           cosignKey: ${{secrets.cosignKey}}
           cosignPassword: ${{secrets.cosignPassword}}
           buildArgs: |
-            NUGET_SOURCE_NAME: ${{ inputs.nugetSourceName }}
-            NUGET_SOURCE_URL: ${{ inputs.nugetSourceUrl }}
-            NUGET_USERNAME: ${{ github.actor }}
-            NUGET_PASSWORD: ${{ secrets.githubToken }}
+            NUGET_SOURCE_NAME=${{ inputs.nugetSourceName }}
+            NUGET_SOURCE_URL=${{ inputs.nugetSourceUrl }}
+            NUGET_USERNAME=${{ github.actor }}
+            NUGET_PASSWORD=${{ secrets.githubToken }}
       - name: Update ArgoCD
         if: inputs.imageName != ''
         uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@main


### PR DESCRIPTION
## Summary by Sourcery

Fix the syntax for GitHub Actions build arguments to properly pass NuGet credentials.

Bug Fixes:
- Switch buildArgs entries from colon-separated to equals-separated syntax to ensure correct variable assignment

CI:
- Update build-publish GitHub Actions workflow to use '=' in buildArgs for NUGET_SOURCE_NAME, NUGET_SOURCE_URL, NUGET_USERNAME, and NUGET_PASSWORD