### PR TITLE
Removed nuget password from build arguments.

### DIFF
--- a/.github/actions/build-publish-sign-docker/action.yaml
+++ b/.github/actions/build-publish-sign-docker/action.yaml
@@ -42,6 +42,10 @@ inputs:
     required: false
     description: "Build arguments for Docker build (e.g., NUGET_SOURCE_URL=...)"
     default: ''
+  secrets:
+    required: false # Set to 'true' if the NuGet password is always required
+    description: "Secrets to pass to the Docker build (e.g., nuget_password=...)"
+    default: '' # Provide a default empty string if not always required
 runs:
   using: "composite"
   steps:

--- a/.github/actions/build-publish-sign-docker/action.yaml
+++ b/.github/actions/build-publish-sign-docker/action.yaml
@@ -88,8 +88,7 @@ runs:
           org.opencontainers.image.revision=${{ inputs.sha }}
           org.opencontainers.image.version=${{ inputs.version }}
         build-args: ${{ inputs.buildArgs }}
-        secrets: |
-          nuget_password=${{ inputs.password }}
+        secrets: ${{ inputs.secrets }}
     - name: sign container image
       run: |
         cosign sign --key env://COSIGN_KEY "${{ env.IMAGE }}@${{ env.DIGEST }}" --recursive=true --yes=true

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -117,7 +117,6 @@ jobs:
             NUGET_SOURCE_NAME=github
             NUGET_SOURCE_URL=https://nuget.pkg.github.com/innago-property-management/index.json
             NUGET_USERNAME=${{ github.actor }}
-            NUGET_PASSWORD=${{ secrets.githubToken }}
           secrets: |
             nuget_password=${{ secrets.githubToken }}
       - name: Update ArgoCD


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove NUGET_PASSWORD environment variable from build arguments to prevent leaking the secret.