### PR TITLE
added dockerfile to the inputs section

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -45,6 +45,16 @@ on:
         description: "Test project discovery is from the solution if this is not set."
         default: "."
         type: string
+      dockerfileContext:
+        required: false
+        description: "The build context for the Docker image. Relative to repository root."
+        type: string
+        default: '.'
+      dockerfilePath:
+        required: false
+        description: "The path to the Dockerfile relative to the build context."
+        type: string
+        default: './Dockerfile'
 
     secrets:
       githubToken:
@@ -56,16 +66,7 @@ on:
       cosignPassword:
         description: "Cosign password"
         required: true
-    dockerfileContext:
-      required: false
-      description: "The build context for the Docker image. Relative to repository root."
-      type: string
-      default: '.'
-    dockerfilePath:
-      required: false
-      description: "The path to the Dockerfile relative to the build context."
-      type: string
-      default: './Dockerfile'
+    
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -128,6 +129,8 @@ jobs:
             NUGET_USERNAME=${{ github.actor }}
           secrets: |
             nuget_password=${{ secrets.githubToken }}
+          dockerfileContext: ${{inputs.dockerfileContext}}
+          dockerfilePath: ${{inputs.dockerfilePath}}
       - name: Update ArgoCD
         if: inputs.imageName != ''
         uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@main


### PR DESCRIPTION
## Summary by Sourcery

Introduce configurable Docker build settings in the CI workflow by exposing context and Dockerfile path as inputs and cleaning up duplicate definitions.

CI:
- Add workflow_dispatch inputs dockerfileContext and dockerfilePath to customize the Docker build
- Remove redundant dockerfileContext and dockerfilePath definitions and pass the new inputs into the build step