### PR TITLE
Skips ArgoCD update if branch exists

### DIFF
--- a/.github/actions/update-argocd/action.yaml
+++ b/.github/actions/update-argocd/action.yaml
@@ -58,6 +58,12 @@ runs:
 
         fileName="value-overrides-${environment}.yaml"
         branchName="automated/${folderName}-${tag}"
+        
+        if git show-ref --verify --quiet "refs/heads/${branchName}"; then
+          echo "${branchName} already exists -- nothing to do"
+          exit 0
+        fi
+        
         git checkout -b "${branchName}"
         fullName="helm-values/${folderName}/${fileName}"
         fullName=$(realpath "${fullName}")

--- a/.github/actions/update-argocd/action.yaml
+++ b/.github/actions/update-argocd/action.yaml
@@ -59,7 +59,7 @@ runs:
         fileName="value-overrides-${environment}.yaml"
         branchName="automated/${folderName}-${tag}"
         
-        if git show-ref --verify --quiet "refs/heads/${branchName}"; then
+        if git ls-remote --heads origin ${branchName}; then
           echo "${branchName} already exists -- nothing to do"
           exit 0
         fi

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get Latest Tag
         id: get_latest_tag
         run: |
-          git fetch
+          git fetch --tags --prune --force
           latest_tag=$(git tag -l --sort=v:refname | tail -n 1)
           latest_tag=${latest_tag:-0.0.1}
           echo "current version is: $latest_tag"
@@ -44,7 +44,11 @@ jobs:
               export ASSEMBLY_VERSION="$NEW_TAG.${{ github.run_number }}"
             else
               echo "feat"
-              export VERSION="$NEW_TAG-feat-${{ github.run_number }}"
+              BRANCH_RAW=$(git rev-parse --abbrev-ref HEAD)
+              echo "Current branch (raw): $BRANCH_RAW"
+              BRANCH_SANITIZED=$(echo "$BRANCH_RAW" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9\/-]+/-/g' | sed -E 's/^-+|-+$//g' | sed -E 's/\/+/-/g')
+              echo "Current branch (sanitized): $BRANCH_SANITIZED"
+              export VERSION="$NEW_TAG-feat-${BRANCH_SANITIZED}-${{ github.run_number }}"
               export ASSEMBLY_VERSION="$NEW_TAG.${{ github.run_number }}"
             fi
           else

--- a/.idea/HudSettings.xml
+++ b/.idea/HudSettings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="HudSettings">
+    <option name="environment" value="{&quot;id&quot;:&quot;384&quot;,&quot;name&quot;:&quot;production&quot;,&quot;totalFunctions&quot;:0}" />
+    <option name="verbosityLevel" value="Level 2: All Significant Functions" />
+  </component>
+</project>


### PR DESCRIPTION
## Summary by Sourcery

Skip redundant ArgoCD branch creation by checking for existing branches and exiting early

Enhancements:
- Skip ArgoCD branch creation when the target branch already exists

Chores:
- Add .idea/HudSettings.xml IDE configuration file