### PR TITLE
Adds Docker Buildx caching to improve build times.

### DIFF
--- a/.github/actions/build-publish-sign-docker/action.yaml
+++ b/.github/actions/build-publish-sign-docker/action.yaml
@@ -98,6 +98,8 @@ runs:
           org.opencontainers.image.version=${{ inputs.version }}
         build-args: ${{ inputs.buildArgs }}
         secrets: ${{ inputs.secrets }}
+        cache-from: type=gha, scope=${{ github.repository }}
+        cache-to: type=gha, mode=max, scope=${{ github.repository }}
     - name: Publish migrations image
       id: publish-migrations
       if: ${{ inputs.migrationsDockerfilePath && (inputs.migrationsDockerfilePath) != '' }}
@@ -127,6 +129,8 @@ runs:
           org.opencontainers.image.version=${{ inputs.version }}
         build-args: ${{ inputs.buildArgs }}
         secrets: ${{ inputs.secrets }}
+        cache-from: type=gha, scope=${{ github.repository }}
+        cache-to: type=gha, mode=max, scope=${{ github.repository }}
       
     - name: sign container image
       run: |


### PR DESCRIPTION
## Summary by Sourcery

Enable Docker Buildx layer caching in the build-publish-sign-docker GitHub Actions workflow to accelerate image builds.

CI:
- Add cache-from and cache-to parameters to the primary image build step using GitHub Actions cache for layer reuse.
- Add cache-from and cache-to parameters to the migrations image build step using GitHub Actions cache for layer reuse.