### PR TITLE
Uses input for .NET SDK version

### DIFF
--- a/.github/actions/build-dotnet/action.yaml
+++ b/.github/actions/build-dotnet/action.yaml
@@ -16,15 +16,19 @@ inputs:
     required: true
     description: "Test project discovery is from the solution if this is not set."
     default: "."
+  dotnet-version:
+    required: false
+    description: ".NET SDK version(s) to install - a multi-line string"
+    default: |
+      8.x
+      9.x
 runs:
   using: "composite"
   steps:
     - name: Setup .NET
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
       with:
-        dotnet-version: |
-          8.x
-          9.x
+        dotnet-version: ${{ inputs.dotnet-version }}
     - name: Build
       shell: bash
       env:


### PR DESCRIPTION
## Summary by Sourcery

Parameterize the .NET SDK version in the build-dotnet GitHub Action by introducing a new input and replacing the hardcoded versions.

Enhancements:
- Add a new optional dotnet-version input with a multi-line default of '8.x' and '9.x'.
- Replace the hardcoded SDK versions in the setup-dotnet step with the dotnet-version input.