### PR TITLE
Adds optional SLSA provenance generation to build workflow.

### DIFF
--- a/.github/actions/slsa/action.yaml
+++ b/.github/actions/slsa/action.yaml
@@ -1,0 +1,23 @@
+description: "Generates SLSA provenance"
+
+inputs:
+  artifact_path:
+    required: true
+    description: "path to build artifacts"
+
+runs:
+  using: composite
+  steps:
+    - name: slsa-hashes
+      id: hashes
+      shell: bash
+      env:
+        artifact_path: ${{ inputs.artifact_path }}
+      run: |
+        echo "HASHES=$(sha256sum .github/**/*.y* ${artifact_path}/**/* | base64 -w0)" >> "$GITHUB_OUTPUT"
+    - name: slsa-generation
+      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+      env:
+        HASHES: ${{ env.HASHES }}
+      with: 
+        base64-subjects: ${HASHES}

--- a/.github/actions/slsa/action.yaml
+++ b/.github/actions/slsa/action.yaml
@@ -14,10 +14,9 @@ runs:
       env:
         artifact_path: ${{ inputs.artifact_path }}
       run: |
-        echo "HASHES=$(sha256sum .github/**/*.y* ${artifact_path}/**/* | base64 -w0)" >> "$GITHUB_OUTPUT"
+        shopt -s nullglob
+        echo "HASHES=$(sha256sum .github/*.y* .github/**/*.y* ${artifact_path}/**/* | base64 -w0)" >> "$GITHUB_OUTPUT"
     - name: slsa-generation
       uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
-      env:
-        HASHES: ${{ env.HASHES }}
       with: 
-        base64-subjects: ${HASHES}
+        base64-subjects: ${{ steps.hashes.outputs.HASHES }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -22,6 +22,11 @@ on:
         description: "Test project discovery is from the solution if this is not set."
         default: "."
         type: string
+      slsa:
+        required: false
+        default: false
+        description: "flag to enable slsa"
+        type: boolean
 
   workflow_call:
     inputs:
@@ -103,6 +108,9 @@ jobs:
       - name: Generate SBOM
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         uses: innago-property-management/Oui-DELIVER/.github/actions/generate-sbom-dotnet@main
+      - name: Generate Build Provenance
+        if: inputs.slsa # github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        uses: innago-property-management/Oui-DELIVER/.github/actions/slsa@main
       - name: Upload SBOMs
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## Summary by Sourcery

Enable optional SLSA provenance generation in the build-publish workflow by adding a new `slsa` flag and corresponding composite action for artifact hashing and provenance creation.

New Features:
- Add an optional `slsa` input to the build-publish workflow to enable SLSA provenance generation
- Introduce a composite GitHub action for generating SLSA provenance including artifact hashing and invocation of the SLSA GitHub generator