### PR TITLE
Adds permissions required to generate provenance.

### DIFF
--- a/.github/workflows/generate-provenance.yaml
+++ b/.github/workflows/generate-provenance.yaml
@@ -48,6 +48,11 @@ jobs:
   generate-provenance:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     needs: generate-hashes
+    permissions: 
+      attestations: write
+      contents: read
+      id-token: write
+      actions: read
     with:
       base64-subjects: ${{ needs.generate-hashes.outputs.hashes }}
       private-repository: true


### PR DESCRIPTION
## Summary by Sourcery

Add explicit permissions to the generate-provenance job in the GitHub Actions workflow to enable attestations and secure token operations.

CI:
- Grant write access to attestations in the generate-provenance job
- Grant read access to repository contents and actions in the generate-provenance job
- Grant write access to the id-token in the generate-provenance job