### PR TITLE
Enforces SLSA provenance generation on main and tag builds.

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -154,7 +154,7 @@ jobs:
           folderName: ${{ github.event.repository.name }}
   generate_provenance:
     needs: build    
-    if: inputs.slsa # github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: inputs.slsa && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     uses: innago-property-management/Oui-DELIVER/.github/workflows/generate-provenance.yaml@main
     permissions: 
       attestations: write


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Restrict SLSA provenance generation to main branch and tag builds by updating the workflow condition.