### PR TITLE
Update build-publish.yml for giving permission action: read

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -76,10 +76,14 @@ on:
       cosignPassword:
         description: "Cosign password"
         required: true
-    
+        
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+  
+permissions:
+  contents: write
+  actions: read
   
 jobs:
   version:


### PR DESCRIPTION
## Summary by Sourcery

Add workflow-level permissions and concurrency to the build-publish GitHub Actions workflow

CI:
- Add concurrency group with cancel-in-progress to prevent overlapping runs
- Specify workflow-level permissions for contents write and actions read
- Remove redundant job-level contents write permission