### PR TITLE
Add merge-checks-generic.yml for script/config repos

### DIFF
--- a/.github/workflows/README-MERGE-CHECKS-GENERIC.md
+++ b/.github/workflows/README-MERGE-CHECKS-GENERIC.md
@@ -1,0 +1,67 @@
+# merge-checks-generic
+
+A reusable workflow for repositories that don't fit Python, Node, Angular, or .NET patterns. Ideal for:
+- Shell script collections
+- Configuration repositories
+- Documentation repos
+- Infrastructure-as-code (Terraform, Helm, etc.)
+- Mixed-language repos
+
+## Jobs
+
+| Job | Description | Always Runs |
+|-----|-------------|-------------|
+| `sast` | Static analysis with Semgrep (all languages) | ✅ |
+| `secrets` | Secret detection with GitLeaks | ✅ |
+| `shellcheck` | Shell script linting | Configurable |
+
+## Usage
+
+### Basic (all defaults)
+
+```yaml
+name: merge-checks
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  merge-checks:
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/merge-checks-generic.yml@main
+```
+
+### With ShellCheck for scripts/ directory
+
+```yaml
+jobs:
+  merge-checks:
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/merge-checks-generic.yml@main
+    with:
+      shellcheck_scandir: "./scripts"
+      shellcheck_severity: "warning"
+```
+
+### Disable ShellCheck (config-only repo)
+
+```yaml
+jobs:
+  merge-checks:
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/merge-checks-generic.yml@main
+    with:
+      shellcheck_enabled: false
+```
+
+## Inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `shellcheck_enabled` | boolean | `true` | Enable ShellCheck job |
+| `shellcheck_scandir` | string | `.` | Directory to scan for shell scripts |
+| `shellcheck_severity` | string | `warning` | Minimum severity: error, warning, info, style |
+
+## Secrets
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `githubToken` | No | GitHub token for API access (optional) |

--- a/.github/workflows/merge-checks-generic.yml
+++ b/.github/workflows/merge-checks-generic.yml
@@ -1,0 +1,72 @@
+name: merge-checks-generic
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      shellcheck_enabled:
+        required: false
+        description: "Enable ShellCheck for shell scripts (default: true)"
+        type: boolean
+        default: true
+      shellcheck_scandir:
+        required: false
+        description: "Directory to scan for shell scripts (default: .)"
+        type: string
+        default: "."
+      shellcheck_severity:
+        required: false
+        description: "Minimum severity to report: error, warning, info, style (default: warning)"
+        type: string
+        default: "warning"
+    secrets:
+      githubToken:
+        description: "GitHub token for API access"
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sast:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: semgrep-action
+        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
+
+  secrets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    container:
+      image: ghcr.io/gitleaks/gitleaks:latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: GitLeaks
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.githubToken }}
+        run: |
+          REPO_NAME=$(echo "${{ github.repository }}" | cut -d '/' -f 2)
+          WORK_DIR="/__w/${{ github.repository_owner }}/${REPO_NAME}"
+          CONTAINER_WORK_DIR="/__w/${REPO_NAME}/${REPO_NAME}"
+          git config --global --add safe.directory "$WORK_DIR"
+          git config --global --add safe.directory "$CONTAINER_WORK_DIR"
+          gitleaks git --verbose --log-level trace --log-opts="-n 10"
+
+  shellcheck:
+    if: ${{ inputs.shellcheck_enabled }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+        with:
+          scandir: ${{ inputs.shellcheck_scandir }}
+          severity: ${{ inputs.shellcheck_severity }}


### PR DESCRIPTION
## Summary

- New reusable workflow for repos that don't fit Python/Node/Angular/.NET patterns
- Ideal for shell scripts, config repos, IaC, documentation repos

## Jobs

| Job | Description | Always Runs |
|-----|-------------|-------------|
| `sast` | Static analysis with Semgrep | ✅ |
| `secrets` | Secret detection with GitLeaks | ✅ |
| `shellcheck` | Shell script linting | Configurable |

## Usage

```yaml
jobs:
  merge-checks:
    uses: innago-property-management/Oui-DELIVER/.github/workflows/merge-checks-generic.yml@main
    with:
      shellcheck_scandir: "./scripts"
```

## Background

Gap identified during `github-best-practices-enforcement` repo setup dogfooding exercise.

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test in github-best-practices-enforcement repo after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a reusable generic merge-checks workflow for non-standard repositories and document how to consume it.

New Features:
- Introduce a generic GitHub Actions workflow providing SAST, secret scanning, and optional ShellCheck linting for script/config-style repositories.

Documentation:
- Add README documenting usage, configuration options, inputs, and secrets for the generic merge-checks workflow.