### PR TITLE
fix(ci): add allowed_bots to claude-code-action workflows

### DIFF
--- a/.github/workflows/claude-code-mention.yml
+++ b/.github/workflows/claude-code-mention.yml
@@ -94,6 +94,7 @@ jobs:
       - name: Run Claude Code Mention Handler
         uses: anthropics/claude-code-action@v1
         with:
+          allowed_bots: "auto-pr-user[bot],dependabot[bot]"
           anthropic_api_key: ${{ secrets.anthropicKey || secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.githubToken || secrets.GITHUB_TOKEN }}
           settings: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
+          allowed_bots: "auto-pr-user[bot],dependabot[bot]"
           anthropic_api_key: ${{ secrets.anthropicKey || secrets.ANTHROPIC_API_KEY }}
           # github_token commented out to use Claude's default identity instead of github-actions[bot]
           # github_token: ${{ secrets.githubToken || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR fixes CI failures caused by Anthropic's claude-code-action security update that now requires explicit bot allowlisting.

### Changes
- Added `allowed_bots: "auto-pr-user[bot],dependabot[bot]"` to claude-code-action workflow steps

### Why
The claude-code-action now rejects workflows triggered by bots unless they are explicitly allowed. This was blocking auto-pr-user bot PRs and dependabot PRs from running Claude code reviews.

### Files Modified
- .github/workflows/claude-code-mention.yml
- .github/workflows/claude-code-review.yml

---
Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Whitelist auto-pr-user[bot] and dependabot[bot] in Claude code mention and review GitHub workflows to satisfy the action's allowed_bots requirement.