### PR TITLE
fix(kaizen-sweep): Add critical repo safety guardrails

### DIFF
--- a/.github/skills/kaizen-sweep/SKILL.md
+++ b/.github/skills/kaizen-sweep/SKILL.md
@@ -2,6 +2,33 @@
 
 You are performing a scheduled maintainability review of a legacy codebase. Your goal is incremental improvement over time - not transformation, not perfection.
 
+## CRITICAL: Repository Safety
+
+**YOU MUST ONLY COMMIT TO THE TARGET REPOSITORY.**
+
+The working directory structure is:
+- `/` - The TARGET repository (where you should make changes)
+- `/oui-deliver-checkout/` - READ-ONLY reference for skill files (DO NOT MODIFY)
+
+### NEVER do these things:
+- `cd oui-deliver-checkout` and run git commands
+- `git add` or `git commit` anything in `oui-deliver-checkout/`
+- Create or modify files in `oui-deliver-checkout/`
+
+### ALWAYS verify before committing:
+```bash
+# Confirm you're in the target repo, NOT oui-deliver-checkout
+pwd
+git remote -v  # Should show the TARGET repo, not Oui-DELIVER
+```
+
+**WHY THIS MATTERS:** Committing to the wrong repository risks:
+1. **Secrets leak** - Target repo secrets could be pushed to Oui-DELIVER
+2. **IP leak** - Target repo code could be exposed in Oui-DELIVER history
+3. **Repo corruption** - Oui-DELIVER history had to be destroyed to fix a previous incident
+
+If you are uncertain which repository you're in, STOP and output `ERROR: Repository context unclear`.
+
 ## Context
 
 This file was selected for review based on complexity metrics or modification history. No one is actively working on it right now. Your suggestions will be proposed as a standalone PR for an engineer to review when they have capacity.


### PR DESCRIPTION
## Summary
Adds explicit instructions to the kaizen-sweep skill preventing Claude from accidentally committing to the Oui-DELIVER checkout instead of the target repository.

## Background
A previous incident occurred where Claude committed to the wrong repository, causing a secrets/IP leak that required complete history destruction to remediate.

## Changes
Added a new **CRITICAL: Repository Safety** section at the top of the skill that:

1. **Documents the directory structure** - Makes clear that `/` is the target repo and `/oui-deliver-checkout/` is read-only
2. **Lists forbidden actions** - Explicitly prohibits `cd oui-deliver-checkout` + git commands
3. **Provides verification commands** - `pwd` and `git remote -v` to confirm context
4. **Explains consequences** - Secrets leak, IP leak, and repo corruption risks
5. **Defines error behavior** - Output `ERROR: Repository context unclear` if uncertain

## Testing
- The updated skill will be pulled by target repos via sparse checkout
- Next kaizen sweep run will use these guardrails

## Related
- Kaizen sweep enabled on: cygnus, argocd-shared, litmus-chaos-hub, cygnus_supervisor
- helm-charts pending (needs PR for branch protection)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Strengthen repository safety guardrails for the kaizen-sweep automation skill to prevent commits to the wrong checkout.

Enhancements:
- Add a CRITICAL repository safety section to kaizen-sweep instructions clarifying directory structure, allowed actions, and consequences of misuse.

Documentation:
- Document explicit verification steps and error behavior for ensuring commits only target the correct repository in kaizen-sweep runs.