### PR TITLE
fix: use @main for detect-build-type action

### DIFF
--- a/.github/workflows/build-publish-angular.yml
+++ b/.github/workflows/build-publish-angular.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: Detect build type
         id: detect
-        uses: innago-property-management/Oui-DELIVER/.github/actions/detect-build-type@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/detect-build-type@main
 
   build:
     runs-on: Linux-x64__16-core__64GB-RAM

--- a/.github/workflows/build-publish-nextjs.yml
+++ b/.github/workflows/build-publish-nextjs.yml
@@ -125,7 +125,7 @@ jobs:
     steps:
       - name: Detect build type
         id: detect
-        uses: innago-property-management/Oui-DELIVER/.github/actions/detect-build-type@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/detect-build-type@main
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-publish-node.yml
+++ b/.github/workflows/build-publish-node.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Detect build type
         id: detect
-        uses: innago-property-management/Oui-DELIVER/.github/actions/detect-build-type@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/detect-build-type@main
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-publish-python.yml
+++ b/.github/workflows/build-publish-python.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Detect build type
         id: detect
-        uses: innago-property-management/Oui-DELIVER/.github/actions/detect-build-type@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/detect-build-type@main
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -105,7 +105,7 @@ jobs:
     steps:
       - name: Detect build type
         id: detect
-        uses: innago-property-management/Oui-DELIVER/.github/actions/detect-build-type@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/detect-build-type@main
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Updates detect-build-type action reference from `@v2` to `@main`
- The v2 tag predates this action, so it can't be found at that ref

## Root Cause
Action was merged to main but v2 tag is protected and wasn't updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update all build-publish workflows to use the detect-build-type composite action from the @main ref instead of the outdated @v2 tag.