### PR TITLE
chore: update Oui-DELIVER workflow references from @v2 to @main

### DIFF
--- a/.github/workflows/build-publish-angular.yml
+++ b/.github/workflows/build-publish-angular.yml
@@ -74,7 +74,7 @@ permissions:
 
 jobs:
   version:
-    uses: innago-property-management/Oui-DELIVER/.github/workflows/semver.yml@v2
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/semver.yml@main
     permissions:
       contents: read
 
@@ -127,7 +127,7 @@ jobs:
       - name: UI Build
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Build
-        uses: innago-property-management/Oui-DELIVER/.github/actions/build-angular@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/build-angular@main
         with:
           npm_token: ${{ secrets.npm_token }}
           node_version: "${{ inputs.node_version }}"
@@ -153,7 +153,7 @@ jobs:
       #     overwrite: 'true'
       - name: Publish Container Image
         if: inputs.imageName != ''
-        uses: innago-property-management/Oui-DELIVER/.github/actions/build-publish-sign-docker@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/build-publish-sign-docker@main
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -169,7 +169,7 @@ jobs:
           cosignPassword: ${{secrets.cosignPassword}}
       - name: Update ArgoCD
         if: inputs.imageName != ''
-        uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@main
         with:
           githubToken: ${{ secrets.githubToken }}
           repoName: ${{ inputs.argoCdRepoName }}

--- a/.github/workflows/build-publish-nextjs.yml
+++ b/.github/workflows/build-publish-nextjs.yml
@@ -107,7 +107,7 @@ permissions:
 
 jobs:
   version:
-    uses: innago-property-management/Oui-DELIVER/.github/workflows/semver.yml@v2
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/semver.yml@main
     permissions:
       contents: read
 
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Build Next.js
-        uses: innago-property-management/Oui-DELIVER/.github/actions/build-nextjs@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/build-nextjs@main
         with:
           version: ${{ needs.version.outputs.version }}
           node_version: "${{ inputs.node_version }}"
@@ -167,7 +167,7 @@ jobs:
 
       - name: Publish Container Image
         if: inputs.imageName != ''
-        uses: innago-property-management/Oui-DELIVER/.github/actions/build-publish-sign-docker@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/build-publish-sign-docker@main
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -187,7 +187,7 @@ jobs:
 
       - name: Update ArgoCD
         if: inputs.imageName != ''
-        uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@main
         with:
           githubToken: ${{ secrets.githubToken }}
           repoName: ${{ inputs.argoCdRepoName }}
@@ -213,7 +213,7 @@ jobs:
   generate_provenance:
     needs: build
     if: inputs.slsa && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
-    uses: innago-property-management/Oui-DELIVER/.github/workflows/generate-provenance.yaml@v2
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/generate-provenance.yaml@main
     permissions:
       attestations: write
       id-token: write

--- a/.github/workflows/build-publish-node.yml
+++ b/.github/workflows/build-publish-node.yml
@@ -67,7 +67,7 @@ permissions:
 
 jobs:
   version:
-    uses: innago-property-management/Oui-DELIVER/.github/workflows/semver.yml@v2
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/semver.yml@main
     permissions:
       contents: read
 
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Build
-        uses: innago-property-management/Oui-DELIVER/.github/actions/build-node@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/build-node@main
         with:
           version: ${{ needs.version.outputs.version }}
           githubToken: "${{ secrets.GITHUB_TOKEN }}"
@@ -119,7 +119,7 @@ jobs:
           overwrite: 'true'
       - name: Publish Container Image
         if: inputs.imageName != ''
-        uses: innago-property-management/Oui-DELIVER/.github/actions/build-publish-sign-docker@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/build-publish-sign-docker@main
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -135,7 +135,7 @@ jobs:
           cosignPassword: ${{secrets.cosignPassword}}
       - name: Update ArgoCD
         if: inputs.imageName != ''
-        uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@main
         with:
           githubToken: ${{ secrets.githubToken }}
           repoName: ${{ inputs.argoCdRepoName }}

--- a/.github/workflows/build-publish-python.yml
+++ b/.github/workflows/build-publish-python.yml
@@ -67,7 +67,7 @@ permissions:
   
 jobs:
   version:
-    uses: innago-property-management/Oui-DELIVER/.github/workflows/semver.yml@v2
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/semver.yml@main
     permissions:
       contents: read
 
@@ -101,13 +101,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Build
-        uses: innago-property-management/Oui-DELIVER/.github/actions/build-python@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/build-python@main
         with:
           version: ${{ needs.version.outputs.version }}
           githubToken: "${{ secrets.GITHUB_TOKEN }}" 
       - name: Publish Container Image
         if: inputs.imageName != ''
-        uses: innago-property-management/Oui-DELIVER/.github/actions/build-publish-sign-docker@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/build-publish-sign-docker@main
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -131,7 +131,7 @@ jobs:
           migrationsDockerfilePath: ${{inputs.migrationsDockerfilePath}}
       - name: Update ArgoCD
         if: inputs.imageName != ''
-        uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@main
         with:
           githubToken: ${{ secrets.githubToken }}
           repoName: ${{ inputs.argoCdRepoName }}
@@ -157,7 +157,7 @@ jobs:
   generate_provenance:
     needs: build    
     if: inputs.slsa && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
-    uses: innago-property-management/Oui-DELIVER/.github/workflows/generate-provenance.yaml@v2
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/generate-provenance.yaml@main
     permissions: 
       attestations: write
       id-token: write

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -87,7 +87,7 @@ permissions:
 
 jobs:
   version:
-    uses: innago-property-management/Oui-DELIVER/.github/workflows/semver.yml@v2
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/semver.yml@main
     permissions:
       contents: read
 
@@ -124,7 +124,7 @@ jobs:
       - name: Build and Test
         # Skip on release for Docker-only repos (tests already passed in PR)
         if: needs.detect.outputs.skip_tests != 'true'
-        uses: innago-property-management/Oui-DELIVER/.github/actions/build-dotnet@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/build-dotnet@main
         with:
           version: ${{ needs.version.outputs.version }}
           githubToken: "${{ secrets.GITHUB_TOKEN }}"
@@ -153,13 +153,13 @@ jobs:
 
       - name: Push Nuget packages
         if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && needs.detect.outputs.has_nuget == 'true'
-        uses: innago-property-management/Oui-DELIVER/.github/actions/push-nuget-packages@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/push-nuget-packages@main
         with:
           pushToken: "${{ secrets.githubToken }}"
 
       - name: Generate SBOM
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
-        uses: innago-property-management/Oui-DELIVER/.github/actions/generate-sbom-dotnet@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/generate-sbom-dotnet@main
 
       - name: Upload SBOMs
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
@@ -171,7 +171,7 @@ jobs:
 
       - name: Publish Container Image
         if: inputs.imageName != ''
-        uses: innago-property-management/Oui-DELIVER/.github/actions/build-publish-sign-docker@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/build-publish-sign-docker@main
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -196,7 +196,7 @@ jobs:
 
       - name: Update ArgoCD
         if: inputs.imageName != ''
-        uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@main
         with:
           githubToken: ${{ secrets.githubToken }}
           repoName: ${{ inputs.argoCdRepoName }}
@@ -222,7 +222,7 @@ jobs:
   generate_provenance:
     needs: build
     if: inputs.slsa && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
-    uses: innago-property-management/Oui-DELIVER/.github/workflows/generate-provenance.yaml@v2
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/generate-provenance.yaml@main
     permissions:
       attestations: write
       id-token: write

--- a/.github/workflows/deployment-risk-assessment-internal.yml
+++ b/.github/workflows/deployment-risk-assessment-internal.yml
@@ -48,7 +48,7 @@ jobs:
       pull-requests: write
     needs:
       - preflight
-    uses: innago-property-management/Oui-DELIVER/.github/workflows/deployment-risk-assessment.yml@v2
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/deployment-risk-assessment.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number || fromJSON(inputs.pr_number) }}
       base_branch: ${{ github.event.pull_request.base.ref || inputs.base_branch }}

--- a/.github/workflows/kaizen-code-review-internal.yml
+++ b/.github/workflows/kaizen-code-review-internal.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
       issues: read
       id-token: write
-    uses: innago-property-management/Oui-DELIVER/.github/workflows/kaizen-code-review.yml@v2
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/kaizen-code-review.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       repository: ${{ github.repository }}

--- a/.github/workflows/merge-checks-angular.yml
+++ b/.github/workflows/merge-checks-angular.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: actions/setup-node@v6.2.0
-      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@v2
+      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@main
         with:
           node-version: ${{ inputs.node_version }}
           npm_token: ${{ secrets.npm_token }}
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: actions/setup-node@v6.2.0
-      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@v2
+      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@main
         with:
           node-version: ${{ inputs.node_version }}
           npm_token: ${{ secrets.npm_token }}
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0 # Required for Chromatic
-      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@v2
+      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@main
         with:
           node-version: ${{ inputs.node_version }}
           npm_token: ${{ secrets.npm_token }}
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: actions/setup-node@v6.2.0
-      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@v2
+      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@main
         with:
           node-version: ${{ inputs.node_version }}
           npm_token: ${{ secrets.npm_token }}
@@ -122,7 +122,7 @@ jobs:
           node-version: lts/*
       - name: Install jq
         uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 #v3.2.0
-      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@v2
+      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@main
         with:
           node-version: ${{ inputs.node_version }}
           npm_token: ${{ secrets.npm_token }}
@@ -139,7 +139,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: actions/setup-node@v6.2.0
-      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@v2
+      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@main
         with:
           node-version: ${{ inputs.node_version }}
           npm_token: ${{ secrets.npm_token }}
@@ -155,8 +155,8 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: actions/setup-node@v6.2.0
-      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@v2
-      - uses: innago-property-management/Oui-DELIVER/.github/actions/build-angular@v2
+      - uses: innago-property-management/Oui-DELIVER/.github/actions/setup-npmrc@main
+      - uses: innago-property-management/Oui-DELIVER/.github/actions/build-angular@main
         with:
           node-version: ${{ inputs.node_version }}
           npm_token: ${{ secrets.npm_token }}

--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -198,7 +198,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Check licenses
-        uses: innago-property-management/Oui-DELIVER/.github/actions/check-licenses-action@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/check-licenses-action@main
         with:
           allowed_licenses_path: "${{ inputs.allowed_licenses_path }}"
           ignored_packages_path: "${{ inputs.ignored_packages_path }}"
@@ -210,4 +210,4 @@ jobs:
           overwrite: "true"
   enforceWarningsAsErrors:
     name: Check Warnings as Errors
-    uses: innago-property-management/Oui-DELIVER/.github/workflows/enforce-treat-warnings-as-errors.yaml@v2
+    uses: innago-property-management/Oui-DELIVER/.github/workflows/enforce-treat-warnings-as-errors.yaml@main

--- a/.github/workflows/update-argocd-image.yml
+++ b/.github/workflows/update-argocd-image.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update ArgoCD
-        uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@v2
+        uses: innago-property-management/Oui-DELIVER/.github/actions/update-argocd@main
         with:
           githubToken: ${{ secrets.githubToken }}
           repoName: ${{ inputs.argoCdRepoName }}


### PR DESCRIPTION
## Summary

Updates all workflow and action references to `innago-property-management/Oui-DELIVER` from `@v2` to `@main` for consistency and to track latest changes.

## Changes

| File | References Updated |
|------|-------------------|
| build-publish.yml | 7 |
| build-publish-node.yml | 4 |
| build-publish-nextjs.yml | 5 |
| build-publish-python.yml | 5 |
| build-publish-angular.yml | 4 |
| merge-checks-angular.yml | 8 |
| merge-checks.yml | 2 |
| deployment-risk-assessment-internal.yml | 1 |
| kaizen-code-review-internal.yml | 1 |
| update-argocd-image.yml | 1 |

**Total:** 38 references across 10 files

## Verification

- All changes are scoped to `innago-property-management/Oui-DELIVER` references only
- External actions (e.g., `slsa-framework`) remain unchanged
- All 65 Oui-DELIVER references now use `@main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update GitHub workflows to use the latest Oui-DELIVER reusable workflows and actions from the main branch instead of the v2 tag.

Build:
- Update all innago-property-management/Oui-DELIVER workflow and action references from @v2 to @main across build and deployment workflows.

CI:
- Align merge-check and internal assessment/review workflows to consume Oui-DELIVER reusable workflows and actions from @main instead of @v2.