### PR TITLE
fix: prevent duplicate Kaizen PRs by checking for existing open PRs

### DIFF
--- a/.github/skills/kaizen-sweep/SKILL.md
+++ b/.github/skills/kaizen-sweep/SKILL.md
@@ -132,6 +132,7 @@ SKIP: <filename> - <one sentence reason>
 ```
 
 Valid skip reasons:
+- "Repository already has open Kaizen PR - allowing time for review"
 - "No obvious improvements without broader context"
 - "File is too coupled; changes risk unintended side effects"
 - "Improvements would be subjective or style-based"
@@ -148,14 +149,23 @@ Skipping is a valid and expected outcome. Not every file needs work.
 
 ### Phase 4: Implementation (dry_run=false only)
 
-1. Create branch:
+1. **Check for existing Kaizen PRs** (collision prevention):
+   ```bash
+   # Skip sweep if any open Kaizen PR already exists
+   if gh pr list --state open --json headRefName --jq '.[].headRefName' | grep -q "^kaizen-sweep"; then
+     echo "SKIP: Repository already has open Kaizen PR - allowing time for review"
+     exit 0
+   fi
+   ```
+
+2. Create branch:
    ```bash
    git checkout -b kaizen-sweep/<brief-description>
    ```
 
-2. Make the change using Edit tool
+3. Make the change using Edit tool
 
-3. Commit with message format:
+4. Commit with message format:
    ```
    [kaizen-sweep] <brief description>
 
@@ -165,12 +175,12 @@ Skipping is a valid and expected outcome. Not every file needs work.
    Safe to merge independently. No functional changes.
    ```
 
-4. Push branch:
+5. Push branch:
    ```bash
    git push -u origin kaizen-sweep/<brief-description>
    ```
 
-5. Create PR:
+6. Create PR:
    ```bash
    gh pr create --title "[kaizen-sweep] <brief description>" --body "$(cat <<'EOF'
    ## Kaizen Sweep Improvement


### PR DESCRIPTION
## Problem

Kaizen sweeps were creating duplicate/conflicting PRs when the previous PR was still under review.

**Root cause:**
- Rotation cycle: 2 repos/hour, 20 repos total → **each repo swept every ~10 hours**
- PR review time: Often > 10 hours
- No collision check: Skill created new PR even when old PR existed

**Observed behavior:**
- Same repo getting multiple Kaizen PRs (kaizen-sweep/fix-1, kaizen-sweep/fix-2)
- Often proposing the same fix or conflicting fixes
- PR backlog building up faster than review capacity

## Solution

Added **pre-flight check in Phase 4** (Implementation):

```bash
# Skip sweep if any open Kaizen PR already exists
if gh pr list --state open --json headRefName --jq '.[].headRefName' | grep -q "^kaizen-sweep"; then
  echo "SKIP: Repository already has open Kaizen PR - allowing time for review"
  exit 0
fi
```

**Behavior:**
- Checks for ANY open PR with head branch starting with `kaizen-sweep`
- If found: Skips sweep gracefully (no branch, no commit, no PR)
- If not found: Proceeds with normal sweep

## Impact

- **Forces review velocity to match sweep velocity**
- Repos with open Kaizen PRs won't get new sweeps until reviewed/merged/closed
- No more duplicate/conflicting Kaizen PRs piling up
- Maintains 10-hour rotation for repos WITHOUT open PRs

## Trade-offs

**Pros:**
- ✅ Prevents PR backlog buildup
- ✅ Forces attention on existing improvements before proposing new ones
- ✅ Eliminates conflicts between multiple Kaizen branches

**Cons:**
- ⚠️ If a Kaizen PR sits unreviewed for weeks, that repo gets no new sweeps
- ⚠️ Reduces total sweep velocity when review capacity is low

**Alternative considered (rejected):** Append findings to existing PR instead of skipping
- More complex implementation
- Mixes unrelated improvements in one PR
- Harder to review atomically

## Testing

**Dry run verification:**
```bash
# In a repo with open kaizen-sweep PR:
gh pr list --state open --json headRefName --jq '.[].headRefName' | grep -q "^kaizen-sweep"
echo $?  # Should output 0 (found)

# In a repo without:
gh pr list --state open --json headRefName --jq '.[].headRefName' | grep -q "^kaizen-sweep"
echo $?  # Should output 1 (not found)
```

**Next sweep will validate:**
- Repos with open Kaizen PRs should show "SKIP: Repository already has open Kaizen PR"
- Repos without should proceed normally

## Checklist

- [x] Added pre-flight check before branch creation
- [x] Updated valid skip reasons documentation
- [x] Verified check uses `gh pr list` (already available in workflow)
- [x] No changes to rotation logic or dispatcher
- [x] No changes to workflow concurrency guard

---

🤖 This PR was created by Claude Code

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

## Summary by Sourcery

Add a pre-flight collision check to Kaizen sweep implementation to avoid creating new PRs when an existing Kaizen PR is already open.

Enhancements:
- Document a new valid skip reason when a repository already has an open Kaizen PR.
- Update the implementation phase workflow to check for existing Kaizen PRs before creating branches, commits, and PRs.