### PR TITLE
fix: add id-token: write for OIDC auth in code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,6 +23,7 @@ permissions:
   contents: read
   pull-requests: write
   actions: read
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
Add missing `id-token: write` permission to the reusable code review workflow.

## Root cause
Claude Code Action uses OIDC to authenticate with the Claude GitHub App. The reusable workflow was missing `id-token: write`, causing 3 retry failures:

```
Could not fetch an OIDC token. Did you remember to add `id-token: write`
to your workflow permissions?
```

Observed on: [cygnus-anamnesis PR #19 run](https://github.com/innago-property-management/cygnus-anamnesis/actions/runs/23020299500/job/66854599860?pr=19)

## Fix
One line: `id-token: write` added to the workflow permissions block.

## Test plan
- [ ] Re-run cygnus-anamnesis PR #19 after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Add id-token: write to the GitHub Actions workflow permissions for the Claude code review job.