### PR TITLE
feat: add concurrency controls to 10 workflows

### DIFF
--- a/.github/workflows/auto-pr-internal.yml
+++ b/.github/workflows/auto-pr-internal.yml
@@ -6,10 +6,14 @@ on:
     branches-ignore:
       - main
 
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
   contents: read
   pull-requests: write
-  
+
 jobs:
   pull_request:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-code-review-internal.yml
+++ b/.github/workflows/claude-code-review-internal.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/deployment-risk-assessment-internal.yml
+++ b/.github/workflows/deployment-risk-assessment-internal.yml
@@ -16,6 +16,10 @@ on:
         type: string
         default: 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
 jobs:
   preflight:
     name: Preflight Checks

--- a/.github/workflows/deployment-risk-assessment.yml
+++ b/.github/workflows/deployment-risk-assessment.yml
@@ -29,6 +29,10 @@ on:
         required: true
         description: 'x-api-key to allow passage through WAF'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/dynamic-matrix-poc.yml
+++ b/.github/workflows/dynamic-matrix-poc.yml
@@ -4,7 +4,11 @@ on:
 #      - main
   workflow_dispatch:
 
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
   contents: read
 
 jobs:

--- a/.github/workflows/kaizen-code-review-internal.yml
+++ b/.github/workflows/kaizen-code-review-internal.yml
@@ -10,6 +10,10 @@ on:
         description: "Pull Request number to review"
         type: number
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
 jobs:
   kaizen-review:
     name: Kaizen Code Review

--- a/.github/workflows/kaizen-sweep-caller.yml
+++ b/.github/workflows/kaizen-sweep-caller.yml
@@ -29,6 +29,10 @@ on:
         default: false
         description: 'If true, show full Claude output (may contain sensitive info)'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}
+  cancel-in-progress: true
+
 jobs:
   kaizen-sweep:
     uses: innago-property-management/Oui-DELIVER/.github/workflows/kaizen-sweep.yml@main

--- a/.github/workflows/kaizen-sweep-dispatcher.yml
+++ b/.github/workflows/kaizen-sweep-dispatcher.yml
@@ -20,6 +20,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   actions: write  # Needed to dispatch workflows

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -6,9 +6,13 @@ on:
         description: "Version"
         value: ${{ jobs.version.outputs.version }}
 
-permissions: 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
   contents: read
-  
+
 jobs:
   version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `concurrency` blocks to all 10 workflows that were missing them
- Groups scoped by trigger type: PR number, branch ref, repo, or singleton
- `cancel-in-progress: true` everywhere except kaizen-sweep-dispatcher (avoids aborting matrix jobs mid-flight)

## Workflows Updated

| Workflow | Group Key | Cancel In-Progress |
|---|---|---|
| auto-pr-internal | workflow + ref | yes |
| claude-code-review-internal | workflow + PR# | yes |
| claude.yml (@claude) | workflow + issue/PR# | yes |
| deployment-risk-assessment-internal | workflow + PR# | yes |
| deployment-risk-assessment (reusable) | workflow + PR# | yes |
| dynamic-matrix-poc | workflow + ref | yes |
| kaizen-code-review-internal | workflow + PR# | yes |
| kaizen-sweep-caller | workflow + repo | yes |
| kaizen-sweep-dispatcher | workflow only | **no** |
| semver (reusable) | workflow + ref | yes |

## Why
AI-assisted dev creates rapid push cycles (2-5 min between pushes vs human 15-60 min). Without concurrency controls, superseded commits burn CI minutes on runs that will never matter.

## Test plan
- [ ] Verify workflows still trigger correctly on test PRs
- [ ] Confirm rapid re-push cancels in-progress runs for PR-scoped workflows
- [ ] Verify kaizen-sweep-dispatcher doesn't cancel matrix jobs mid-flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add concurrency controls across multiple GitHub Actions workflows to avoid redundant runs during rapid push cycles.

Enhancements:
- Introduce concurrency groups to 10 GitHub Actions workflows, scoped by branch ref, pull request number, repository, or workflow as appropriate.
- Enable automatic cancellation of in-progress runs for most updated workflows to conserve CI resources, except for the sweep dispatcher workflow which remains non-cancelling to avoid interrupting matrix jobs.