### PR TITLE
fix: tolerate missing git extraheader in update-argocd

### DIFF
--- a/.github/actions/update-argocd/action.yaml
+++ b/.github/actions/update-argocd/action.yaml
@@ -29,7 +29,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        git config --unset-all http.https://github.com/.extraheader
+        git config --unset-all http.https://github.com/.extraheader || true
         git config user.name "${userName}"
         git config user.email "<>"
         origin="https://${userName}:${token}@github.com/${repoName}"


### PR DESCRIPTION
## Summary
The `set -euo pipefail` we added in PR #49 (P2 polish) broke the update-argocd action. `git config --unset-all http.https://github.com/.extraheader` returns exit code 5 when the key doesn't exist, which is now fatal.

Fix: `|| true` on that one command.

**Broke:** cygnus-control-surface PR #50 build
**Root cause:** `git config --unset-all` exit code 5 = key not found (not an error, just "nothing to unset")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent the update-argocd GitHub Action from failing when the http.https://github.com/.extraheader Git config key does not exist.