### PR TITLE
fix: detect GeneratePackageOnBuild as NuGet package marker

### DIFF
--- a/.github/actions/detect-build-type/action.yml
+++ b/.github/actions/detect-build-type/action.yml
@@ -76,8 +76,8 @@ runs:
           echo "has_docker=false" >> $GITHUB_OUTPUT
         fi
 
-        # .NET packages (IsPackable=true in csproj)
-        if grep -rq "<IsPackable>true</IsPackable>" --include="*.csproj" . 2>/dev/null; then
+        # .NET packages (IsPackable=true or GeneratePackageOnBuild=true in csproj)
+        if grep -rqE "<IsPackable>true</IsPackable>|<GeneratePackageOnBuild>true</GeneratePackageOnBuild>" --include="*.csproj" . 2>/dev/null; then
           echo "has_nuget=true" >> $GITHUB_OUTPUT
           echo "::notice::Detected: NuGet package (.NET)"
         else


### PR DESCRIPTION
## Summary
`detect-build-type` only checked for `<IsPackable>true</IsPackable>` when determining if a .NET project produces NuGet packages. Projects using `<GeneratePackageOnBuild>true</GeneratePackageOnBuild>` (like innago-health-checks) were not detected, causing the NuGet publish step to skip on tagged releases.

## Fix
Extended the grep to match either `IsPackable` or `GeneratePackageOnBuild` — both are valid MSBuild properties that indicate a NuGet-producing project.

## Impact
- **innago-health-checks** 2.0.0 tag skipped NuGet publish because of this
- After merge, re-tag or re-run the build to publish the packages

## Test plan
- [ ] Re-run innago-health-checks tagged build → NuGet packages should publish
- [ ] Existing repos with IsPackable continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure NuGet-producing .NET projects using GeneratePackageOnBuild are correctly detected so their packages are published on tagged builds.