### PR TITLE
Enhance TDD rule for regression prevention

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -126,7 +126,7 @@ jobs:
                [TYPE] path/to/file line N — one-sentence imperative fix instruction
                ...
 
-               Run tests after all fixes. Push to the same branch.
+               Regression-prevention TDD Rule: Write a test that fails due to the issue found. Fix the code to pass the test. Refactor. Run tests after all fixes. Push to the same branch.
                ```
 
                </details>


### PR DESCRIPTION
Updated the TDD rule in the code review workflow to specify writing a failing test for regression prevention.

## Summary by Sourcery

Documentation:
- Update the code review workflow instructions to spell out a regression-prevention TDD rule centered on writing a failing test before fixing the issue.