### PR TITLE
Update allowed_bots to allow all bots

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.anthropicKey }}
           track_progress: true
-          allowed_bots: 'auto-pr-user[bot],dependabot[bot]'
+          allowed_bots: '*'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Expand the Claude code review workflow configuration to accept all bot users via a wildcard allowed_bots setting.