### PR TITLE
fix: restore dual-secret auto-pr (app key + token fallback)

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -2,9 +2,12 @@ name: auto-pr
 on:
   workflow_call:
     secrets:
-      auto_pr_private_key:
-        description: "Token with contents:read and pull-requests:write on the calling repo"
+      token:
+        description: "GitHub token with contents:read and pull-requests:write (fallback if app key not provided)"
         required: true
+      auto_pr_private_key:
+        description: "GitHub App PEM private key for bot identity (optional — uses token if not set)"
+        required: false
 
 # No concurrency block — auto-pr is only called via workflow_call from
 # workflows that already have their own concurrency controls.
@@ -14,12 +17,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
+      - name: Create GitHub App Token
+        env:
+          auto_pr_private_key: ${{ secrets.auto_pr_private_key }}
+        if: env.auto_pr_private_key != ''
+        id: app_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.AUTO_PR_APP_ID }}
+          private-key: ${{ secrets.auto_pr_private_key }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ secrets.auto_pr_private_key }}
+          token: ${{ steps.app_token.outputs.token || secrets.token }}
       - name: Create PR if none exists
         env:
-          GH_TOKEN: ${{ secrets.auto_pr_private_key }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token || secrets.token }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
Reverts the single-secret simplification from PR #77 — some repos pass a real PEM app key (e.g. argocd-shared), others pass just a PAT as `token`.

Restores:
- `auto_pr_private_key` (optional) — PEM key → mints app token for bot identity
- `token` (required) — fallback PAT for repos without the app

Keeps the checkout-after-token ordering fix from PR #76.

## What broke
argocd-shared passed a non-PEM value into `create-github-app-token` → `Invalid keyData`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore dual-secret support for the auto-pr workflow, using an optional GitHub App private key with a required token fallback while preserving the checkout ordering fix.

New Features:
- Support using an optional GitHub App PEM private key to mint an app token for the auto-pr bot identity, with automatic fallback when not provided.

Bug Fixes:
- Prevent failures when a non-PEM token is passed by falling back to a standard GitHub token when no valid app private key is supplied.