### PR TITLE
Add visheshsingh-tz as code owner for GitHub files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-.github/CODEOWNERS @jagdishprasad-tz @pawankumar-tz @ashutosh-tz
-.github @jagdishprasad-tz @pawankumar-tz @ashutosh-tz
+.github/CODEOWNERS @jagdishprasad-tz @pawankumar-tz @ashutosh-tz @visheshsingh-tz
+.github @jagdishprasad-tz @pawankumar-tz @ashutosh-tz @visheshsingh-tz
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Adjust CODEOWNERS entries to include visheshsingh-tz for GitHub configuration files.